### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -6,10 +6,15 @@ on:
       - main
       - "feature/**"
 
+permissions:
+  contents: read
+
 jobs:
   bump:
     if: github.ref_name == 'main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
     steps:
@@ -58,6 +63,9 @@ jobs:
     if: github.ref_name == 'main' && !contains(github.event.head_commit.message, '[skip release]')
     needs: bump
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/rust-emulas/emulas-core/security/code-scanning/2](https://github.com/rust-emulas/emulas-core/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow to explicitly define the minimal permissions required for each job. The `bump` job requires `contents: write` to commit changes to the repository, while the `release` job requires `contents: read` and `packages: write` to create a release and upload artifacts. This ensures that the `GITHUB_TOKEN` has only the necessary permissions for each job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
